### PR TITLE
Refactor preset

### DIFF
--- a/src/preset/index.js
+++ b/src/preset/index.js
@@ -3,5 +3,5 @@ export function config(entry = []) {
 }
 
 export function managerEntries(entry = []) {
-  return [...entry, require.resolve('../register')];
+  return [...entry, require.resolve('./register')];
 }

--- a/src/preset/register.js
+++ b/src/preset/register.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { addons, types } from '@storybook/addons';
 
-import { ADDON_ID } from './constants';
-import { OutlineSelector } from './OutlineSelector';
+import { ADDON_ID } from '../constants';
+import { OutlineSelector } from '../OutlineSelector';
 
 addons.register(ADDON_ID, () => {
   addons.add(ADDON_ID, {


### PR DESCRIPTION
## What I did

Move `register` into `preset` directory to reflect a "preset-by-default" addon structure.

We should probably also refactor all the monorepo addons to reflect this structure as well. WDYT?