### PR TITLE
add ts-dedent dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "@storybook/addons": "^6.3.0-beta.6",
     "@storybook/api": "^6.3.0-beta.6",
     "@storybook/components": "^6.3.0-beta.6",
-    "@storybook/core-events": "^6.3.0-beta.6"
+    "@storybook/core-events": "^6.3.0-beta.6",
+    "ts-dedent": "^2.1.1"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9753,7 +9753,7 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
-ts-dedent@^2.0.0:
+ts-dedent@^2.0.0, ts-dedent@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.1.1.tgz#6dd56870bb5493895171334fa5d7e929107e5bbc"
   integrity sha512-riHuwnzAUCfdIeTBNUq7+Yj+ANnrMXo/7+Z74dIdudS7ys2k8aSGMzpJRMFDF7CLwUTbtvi1ZZff/Wl+XxmqIA==


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.3.1-canary.10.7e409b4.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-outline@1.3.1-canary.10.7e409b4.0
  # or 
  yarn add storybook-addon-outline@1.3.1-canary.10.7e409b4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
