### PR TITLE
Add default for the outline global value

### DIFF
--- a/src/preset/addDecorator.js
+++ b/src/preset/addDecorator.js
@@ -1,3 +1,8 @@
 import { withOutline } from '../withOutline';
+import { PARAM_KEY } from '../constants';
 
 export const decorators = [withOutline];
+
+export const globals = {
+  [PARAM_KEY]: false,
+};


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.4.1-canary.14.9e097c8.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-outline@1.4.1-canary.14.9e097c8.0
  # or 
  yarn add storybook-addon-outline@1.4.1-canary.14.9e097c8.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
